### PR TITLE
Add "DisplayOff" to power options for "off"

### DIFF
--- a/devices/roku-tv.groovy
+++ b/devices/roku-tv.groovy
@@ -161,6 +161,7 @@ def parsePowerState(Node body) {
 				} 
 				break;
 			case "PowerOff":
+			case "DisplayOff":
 			case "Headless":
 				if (this.state!="off") {
 					sendEvent(name: "switch", value: "off")


### PR DESCRIPTION
When I power down my series 4 roku tv with the remote, it shows "DisplayOff" as it's power status.