### PR TITLE
Remove extra parameter to httpPost()

### DIFF
--- a/roku/device/roku-tv.groovy
+++ b/roku/device/roku-tv.groovy
@@ -566,7 +566,7 @@ def launchApp(appId) {
     if (logEnable) log.debug "Executing 'launchApp ${appId}'"
     if (appId =~ /^\d+$/ ) {
         try {
-            httpPost([uri:"http://${deviceIp}:8060/launch/${appId}", timeout:3], null) { response ->
+            httpPost([uri:"http://${deviceIp}:8060/launch/${appId}", timeout:3]) { response ->
                 if (response.isSuccess()) {
                     def netId = networkIdForApp(appId)
                     def child = getChildDevice(netId)


### PR DESCRIPTION
This fixes the `MissingMethodException` that is thrown when trying to launch a channel via the child device.

I tested this by testing on my TCLTV 65S405 by trying to launch the Disney+ child device, and it now works as expected.